### PR TITLE
PAMS-BE-18-회원조회 기능 구현

### DIFF
--- a/src/main/java/com/pams/user/controller/UserController.java
+++ b/src/main/java/com/pams/user/controller/UserController.java
@@ -1,8 +1,9 @@
 package com.pams.user.controller;
 
-import java.util.List;
+
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.pams.common.protocol.CommonResponseVO;
-import com.pams.common.protocol.CommonResultCode;
 import com.pams.user.dto.User;
 import com.pams.user.service.UserService;
 
@@ -30,7 +30,7 @@ public class UserController {
     }
 	
 	@RequestMapping(value ="/getUserList", method = RequestMethod.GET)
-	public @ResponseBody CommonResponseVO getUserList(@RequestBody User user) {
+	public @ResponseBody CommonResponseVO getUserList(@ModelAttribute User user) {
 		
 		CommonResponseVO response = userService.getUserList(user);
 		

--- a/src/main/java/com/pams/user/controller/UserController.java
+++ b/src/main/java/com/pams/user/controller/UserController.java
@@ -21,7 +21,6 @@ public class UserController {
 	@Autowired
 	private UserService userService;
 	
-	//Create
 	@RequestMapping(value = "/signup", method = RequestMethod.POST)
     public @ResponseBody CommonResponseVO signUpUser(@RequestBody User user) {
 		
@@ -29,4 +28,12 @@ public class UserController {
 	
         return response;
     }
+	
+	@RequestMapping(value ="/getUserList", method = RequestMethod.GET)
+	public @ResponseBody CommonResponseVO getUserList(@RequestBody User user) {
+		
+		CommonResponseVO response = userService.getUserList(user);
+		
+		return response;
+	}
 }

--- a/src/main/java/com/pams/user/predicate/UserPredicate.java
+++ b/src/main/java/com/pams/user/predicate/UserPredicate.java
@@ -1,0 +1,38 @@
+package com.pams.user.predicate;
+
+import com.pams.common.util.CommonUtils;
+import com.pams.user.dto.QUser;
+import com.pams.user.dto.User;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+
+public class UserPredicate {
+	public static Predicate searchCondition(User user) {
+		
+		QUser userGroup = QUser.user;
+		
+		String userName = user.getName();
+		String userGrade = user.getGrade();
+		String userClubCode = user.getClubCode();
+		String userRoleCode = user.getGrade();
+		
+		BooleanBuilder builder = new BooleanBuilder();
+		
+		if(!CommonUtils.isNull(userName)) {
+			builder.and(userGroup.name.eq(userName));
+		}
+		if(!CommonUtils.isNull(userGrade)) {
+			builder.and(userGroup.grade.eq(userGrade));
+		}
+		if(!CommonUtils.isNull(userClubCode)) {
+			builder.and(userGroup.clubCode.eq(userClubCode));
+		}
+		if(!CommonUtils.isNull(userRoleCode)) {
+			builder.and(userGroup.roleCode.eq(userRoleCode));
+		}
+		builder.and(userGroup.isActive.eq("1"));
+		
+		return builder;
+	}
+
+}

--- a/src/main/java/com/pams/user/predicate/UserPredicate.java
+++ b/src/main/java/com/pams/user/predicate/UserPredicate.java
@@ -14,7 +14,7 @@ public class UserPredicate {
 		String userName = user.getName();
 		String userGrade = user.getGrade();
 		String userClubCode = user.getClubCode();
-		String userRoleCode = user.getGrade();
+		String userRoleCode = user.getRoleCode();
 		
 		BooleanBuilder builder = new BooleanBuilder();
 		

--- a/src/main/java/com/pams/user/repo/UserRepository.java
+++ b/src/main/java/com/pams/user/repo/UserRepository.java
@@ -1,11 +1,12 @@
 package com.pams.user.repo;
 
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import com.pams.user.dto.User;
 
 @Repository
-public interface UserRepository extends CrudRepository<User, Long>{
+public interface UserRepository extends CrudRepository<User, Long>, QuerydslPredicateExecutor<User>{
 
 }

--- a/src/main/java/com/pams/user/service/UserService.java
+++ b/src/main/java/com/pams/user/service/UserService.java
@@ -5,4 +5,6 @@ import com.pams.user.dto.User;
 
 public interface UserService {
 	public CommonResponseVO signUpUser(User user);
+
+	public CommonResponseVO getUserList(User user);
 }

--- a/src/main/java/com/pams/user/service/UserServiceImpl.java
+++ b/src/main/java/com/pams/user/service/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.pams.common.protocol.CommonResponseVO;
 import com.pams.common.protocol.CommonResultCode;
 import com.pams.user.dto.User;
+import com.pams.user.predicate.UserPredicate;
 import com.pams.user.repo.UserRepository;
 
 import lombok.extern.java.Log;
@@ -32,6 +33,25 @@ public class UserServiceImpl implements UserService{
 		response.setResponseMessage(CommonResultCode.SUCCESS_NORMAL.getMessage());
 		response.setResponseData(signUpUser);
 		
+		return response;
+	}
+
+	@Override
+	public CommonResponseVO getUserList(User user) {
+		
+		log.info("<------Request------>");
+		log.info("user_name : " + user.getName());
+		log.info("user_grade : " + user.getGrade());
+		log.info("user_club_code : " + user.getClubCode());
+		log.info("user_role_code : " + user.getRoleCode());
+		log.info("<-------------------->");
+		List<User> userList = (List<User>) userRepo.findAll(UserPredicate.searchCondition(user));
+		
+		CommonResponseVO response = new CommonResponseVO();
+		response.setResponseCode(CommonResultCode.SUCCESS_NORMAL.getCode());
+		response.setResponseMessage(CommonResultCode.SUCCESS_NORMAL.getMessage());
+		response.setResponseDataList(userList);
+	
 		return response;
 	}
 

--- a/src/main/java/com/pams/user/service/UserServiceImpl.java
+++ b/src/main/java/com/pams/user/service/UserServiceImpl.java
@@ -38,13 +38,6 @@ public class UserServiceImpl implements UserService{
 
 	@Override
 	public CommonResponseVO getUserList(User user) {
-		
-		log.info("<------Request------>");
-		log.info("user_name : " + user.getName());
-		log.info("user_grade : " + user.getGrade());
-		log.info("user_club_code : " + user.getClubCode());
-		log.info("user_role_code : " + user.getRoleCode());
-		log.info("<-------------------->");
 		List<User> userList = (List<User>) userRepo.findAll(UserPredicate.searchCondition(user));
 		
 		CommonResponseVO response = new CommonResponseVO();


### PR DESCRIPTION
## 개요

- User 회원정보 조회 기능 구현
  - QueryDsl 추가
  - Controller에 메소드 추가
  - Service에 메소드 추가
  - Predicate 클래스 추가
- Postman을 이용하여 Test

------

## PR 설명

- User 회원정보 조회 기능 구현

  - QueryDsl 추가
    <img src="https://user-images.githubusercontent.com/45187382/65308575-50136780-dbc5-11e9-8d25-822b69f243b9.PNG" alt="QueryDsl pom" style="zoom: 50%;" />
    pom.xml에 Dependency추가

![QueryDsl Repo](https://user-images.githubusercontent.com/45187382/65423630-7dba1400-de44-11e9-93dc-a5c8f5f1e63f.PNG)

       QuerydslPredicateExecutor를 추가하여 Repositiory가 QueryDsl을 실행 할 수 있는 인터페이스를 제공

    

  - Controller 클래스에 메소드 추가

![controller](https://user-images.githubusercontent.com/45187382/65423597-6844ea00-de44-11e9-9a60-fe581c6bdb43.PNG)

    

  - Service 클래스에 메소드 추가

![회원정보조회 service](https://user-images.githubusercontent.com/45187382/65423649-890d3f80-de44-11e9-96aa-6800dff177ff.PNG)

    Service 선언부

![회원정보조회 serviceImpl](https://user-images.githubusercontent.com/45187382/65423651-8dd1f380-de44-11e9-8ae5-3eebb89695d3.PNG)

    Service 구현부

    

  - Predicate 클래스 추가

![Predicate구현](https://user-images.githubusercontent.com/45187382/65423657-91fe1100-de44-11e9-885f-886279b9a5a1.PNG)

  - 이름, 학번, 패, 역할을 입력할 경우 - 입력한 정보와 일치하는 회원 검색
  - 입력하지 않을 경우 - 전체회원 조회

------

- Postman을 이용하여 Test

  - Test 1 - 이름 입력한 경우

![회원정보조회 test 1](https://user-images.githubusercontent.com/45187382/65423664-96c2c500-de44-11e9-8088-cfa55c3810e6.PNG)

  - Test 2 - 학번 입력한 경우

![회원정보조회 test 2](https://user-images.githubusercontent.com/45187382/65423666-99bdb580-de44-11e9-8e44-2303def23cdc.PNG)

  - Test 3 - 패 입력한 경우

![회원정보조회 test 3](https://user-images.githubusercontent.com/45187382/65423672-9cb8a600-de44-11e9-9c39-57fcabe1433f.PNG)

  - Test 4 - 역할 입력한 경우

![회원정보조회 test 4](https://user-images.githubusercontent.com/45187382/65423677-9fb39680-de44-11e9-8c7b-88fb95858f2e.PNG)

  - Test 5 - 아무것도 입력하지 않은 경우

![회원정보조회 test 5](https://user-images.githubusercontent.com/45187382/65423680-a215f080-de44-11e9-98a5-81f367bafb7b.PNG)

  - Test 6 - 없는 정보를 입력한 경우

![회원정보조회 test 6](https://user-images.githubusercontent.com/45187382/65423682-a510e100-de44-11e9-87a4-edfb140b996c.PNG)

  없는 정보를 입력할 경우, 리스트 조회는 나오지 않으나 response message가 "실패"가 나오도록 수정 할 필요가 있음.

------

## 참고자료

- QueryDsl 참고 : https://engkimbs.tistory.com/828
---------------------------
## 수정사항
* 회원정보 조회 GET방식에 맞게 Controller 수정
     * GET방식으로 Postman test
* ServiceImpl의 log부분 삭제
-----------------------
## PR 설명
* 회원정보 조회 수정
![회원정보조회 수정 Controller](https://user-images.githubusercontent.com/45187382/65745409-8fe2cd80-e136-11e9-8b35-a6eb909c635b.PNG)
@RequestBody 대신 @ModelAttribute 어노테이션 사용

   * Postman Test    
![회원정보조회 수정 test 1](https://user-images.githubusercontent.com/45187382/65745590-22836c80-e137-11e9-95c5-857b08137bcd.PNG)

![회원정보조회 수정 test 4](https://user-images.githubusercontent.com/45187382/65745683-742bf700-e137-11e9-8960-0d7cee8d6133.PNG)
     잘못된 파라미터를 입력해도 조회가 되는 문제가 생김. 추후 수정 예정

* ServiceImpl의 log부분 삭제
![회원정보조회 수정 ServiceImpl](https://user-images.githubusercontent.com/45187382/65745501-e3edb200-e136-11e9-86d3-e1e160baa970.PNG)
-------------
## 참고자료
* ModelAttribute와 RequestParam 차이 :  http://wonwoo.ml/index.php/post/1834